### PR TITLE
[PR] Create a combination script that combines ETL together FIX

### DIFF
--- a/pipeline/etl_controller.py
+++ b/pipeline/etl_controller.py
@@ -11,6 +11,7 @@ from load import run_load
 
 def run_pipeline() -> None:
     """Runs each stage of the pipeline in succession."""
+    set_logger()
     logger = get_logger()
     load_dotenv('.env')
 
@@ -30,5 +31,4 @@ def run_pipeline() -> None:
 
 
 if __name__ == "__main__":
-    set_logger()
     run_pipeline()

--- a/pipeline/etl_controller.py
+++ b/pipeline/etl_controller.py
@@ -1,0 +1,34 @@
+"""Script that combines all individual parts of the ETL into one."""
+# pylint: disable=broad-except
+
+import pandas as pd
+from dotenv import load_dotenv
+from utilities import get_logger, set_logger
+from extract import run_extract
+from transform import clean_dataframe
+from load import run_load
+
+
+def run_pipeline() -> None:
+    """Runs each stage of the pipeline in succession."""
+    logger = get_logger()
+    load_dotenv('.env')
+
+    try:
+        logger.info("Extracting...")
+        run_extract('data/output.csv')
+
+        logger.info("Transforming...")
+        raw_df = pd.read_csv('data/output.csv')
+        clean_df = clean_dataframe(raw_df)
+
+        logger.info("Loading...")
+        run_load(clean_df)
+        logger.info("Success!...")
+    except Exception:
+        logger.exception("Critical error. Stopping pipeline")
+
+
+if __name__ == "__main__":
+    set_logger()
+    run_pipeline()

--- a/pipeline/schema.sql
+++ b/pipeline/schema.sql
@@ -35,6 +35,7 @@ CREATE TABLE tag (
 CREATE TABLE merchandise (
     merchandise_id BIGINT GENERATED ALWAYS AS IDENTITY,
     merchandise_name VARCHAR(255),
+    release_date DATE,
     art_url VARCHAR(255),
     url VARCHAR(255) NOT NULL,
     sold_for DECIMAL NOT NULL,
@@ -54,7 +55,7 @@ CREATE TABLE album (
 CREATE TABLE track (
     track_id BIGINT GENERATED ALWAYS AS IDENTITY,
     track_name TEXT NOT NULL,
-    release_date DATE NOT NULL,
+    release_date DATE,
     art_url VARCHAR(255),
     url VARCHAR(255) NOT NULL,
     sold_for DECIMAL NOT NULL,
@@ -174,3 +175,4 @@ ALTER SEQUENCE artist_album_assignment_artist_album_assignment_id_seq RESTART WI
 ALTER SEQUENCE artist_track_assignment_artist_track_assignment_id_seq RESTART WITH 1;
 ALTER SEQUENCE track_tag_assignment_track_tag_assignment_id_seq RESTART WITH 1;
 ALTER SEQUENCE album_tag_assignment_album_tag_assignment_id_seq RESTART WITH 1;
+

--- a/pipeline/web_scraper.py
+++ b/pipeline/web_scraper.py
@@ -26,7 +26,7 @@ def filter_tags(tags: list[str], logger) -> list[str]:
 def get_relevant_html(url: str, logger) -> Tag:
     """Returns the html element containing details on release date and tags."""
 
-    logger.info("Retrieving page to be scraped from ' %s'", url)
+    logger.info("Retrieving page to be scraped from '%s'", url)
     page = requests.get(url, timeout=5)
     soup = BeautifulSoup(page.content, "html.parser")
     results = soup.find(id="pgBd")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Created a combination script that runs all stages of the ETL pipeline as one.
As the ETL pipeline is not yet complete, this script does not currently work and **assumes that calling run_load will output to RDS when finished** 
I have also added documentation

## What user story are you considering for this request?
<!--- Always keep in mind a potential user when writing a request. -->
<!--- "As a X, I want to X, so I can X" -->
As a developer, I want the program to be ran in one script, so I can easily harvest data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows a simple call of this script when hosted on AWS.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Cannot be fully tested as load script is not finished, further issue will be created on refactoring once all stages are complete if it doesn't work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code has a pylint score over 8.5/9.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
