### PR TITLE
[PR] Extend sales report to use SES

### DIFF
--- a/sales_report/report.py
+++ b/sales_report/report.py
@@ -182,13 +182,13 @@ def send_email_with_attachment(path: str):
 
     msg.attach(part)
     ses_client = client('ses', region_name='eu-west-2')
-    logger.info("Attempting to email report to {MVP_EMAIL}")
+    logger.info(f"Attempting to email report to {MVP_EMAIL}")
     response = ses_client.send_raw_email(
         Source=MVP_EMAIL,
         Destinations=[MVP_EMAIL],
         RawMessage={'Data': msg.as_string()}
     )
-    logger.info("Email response: {response}")
+    logger.info("Email response: %s", response)
 
 
 def generate_pdf_and_upload_to_s3():

--- a/sales_report/report.py
+++ b/sales_report/report.py
@@ -182,12 +182,13 @@ def send_email_with_attachment(path: str):
 
     msg.attach(part)
     ses_client = client('ses', region_name='eu-west-2')
+    logger.info("Attempting to email report to {MVP_EMAIL}")
     response = ses_client.send_raw_email(
         Source=MVP_EMAIL,
         Destinations=[MVP_EMAIL],
         RawMessage={'Data': msg.as_string()}
     )
-    print(response)
+    logger.info("Email response: {response}")
 
 
 def generate_pdf_and_upload_to_s3():
@@ -224,8 +225,10 @@ def generate_pdf_and_upload_to_s3():
                     total_album_revenue, total_track_revenue, total_merchandise_revenue)
     logger.info("Report successfully generated.")
     s3_client = connect_to_s3_client(logger)
+    report_path = f"/tmp/daily_bandcamp_report_{date.today()}.pdf"
     upload_file_to_s3(
-        logger, s3_client, f"/tmp/daily_bandcamp_report_{date.today()}.pdf")
+        logger, s3_client, report_path)
+    send_email_with_attachment(report_path)
 
 
 def report_lambda_handler(event, context):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adds and fixes the functionality to send the generated PDF report via AWS's simple email service.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want the PDF report to be scheduled to send once per day via AWS's SES service.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested via monitoring AWS cloudwatch logs and confirmed email received.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code has a pylint score over 8.5/9.
- [x] All new and existing tests passed.
